### PR TITLE
test: create http test

### DIFF
--- a/domain/account/usecase_mock.go
+++ b/domain/account/usecase_mock.go
@@ -1,0 +1,58 @@
+package account
+
+import (
+	"github.com/francisleide/ChallengeGo/domain/entities"
+	"github.com/stretchr/testify/mock"
+)
+
+type UsecaseMock struct {
+	mock.Mock
+}
+
+//implementation of usecases account interfaces
+
+/*CreateAccount(account entities.AccountInput) (entities.Account, error)
+ListAll() ([]entities.Account, error)
+Deposit(CPF string, amount float64) error
+Withdraw(CPF string, amount float64) error
+GetBalance(accountID string) (float64, error)
+GetAccountByID(ID string) (entities.Account, error)
+GetAccountByCPF(CPF string) (entities.Account, error)*/
+
+func (mock *UsecaseMock) CreateAccount(account entities.AccountInput) (entities.Account, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(entities.Account), args.Error(1)
+}
+
+func (mock *UsecaseMock) ListAll() ([]entities.Account, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.([]entities.Account), args.Error(1)
+}
+
+func (mock *UsecaseMock) Deposit(CPF string, amount float64) error {
+	args := mock.Called()
+	return args.Error(0)
+}
+
+func (mock *UsecaseMock) Withdraw(CPF string, amount float64) error {
+	args := mock.Called()
+	return args.Error(1)
+}
+
+func (mock *UsecaseMock) GetBalance(accountID string) (float64, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(float64), args.Error(1)
+}
+func (mock *UsecaseMock) GetAccountByID(ID string) (entities.Account, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(entities.Account), args.Error(1)
+}
+func (mock *UsecaseMock) GetAccountByCPF(CPF string) (entities.Account, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(entities.Account), args.Error(1)
+}

--- a/domain/auth/usecase_mock.go
+++ b/domain/auth/usecase_mock.go
@@ -1,0 +1,17 @@
+package auth
+
+import "github.com/stretchr/testify/mock"
+
+type UsecaseMock struct {
+	mock.Mock
+}
+
+func (mock *UsecaseMock) CreateToken(CPF string, secret string) (string, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(string), args.Error(1)
+}
+func (mock *UsecaseMock) Login(CPF, secret string) error {
+	args := mock.Called()
+	return args.Error(0)
+}

--- a/domain/transfer/repository_mock.go
+++ b/domain/transfer/repository_mock.go
@@ -11,10 +11,9 @@ type MockRepository struct {
 
 //implementation of repository interfaces
 
-func (mock *MockRepository) InsertTransfer(transfer entities.Transfer) (entities.Transfer, error) {
+func (mock *MockRepository) InsertTransfer(transfer entities.Transfer) error {
 	args := mock.Called()
-	result := args.Get(0)
-	return result.(entities.Transfer), args.Error(1)
+	return args.Error(0)
 }
 func (mock *MockRepository) UpdateBalance(ID string, balance float64) error {
 	args := mock.Called()

--- a/domain/transfer/usecase.go
+++ b/domain/transfer/usecase.go
@@ -10,7 +10,7 @@ type UseCase interface {
 }
 
 type Repository interface {
-	InsertTransfer(transfer entities.Transfer) (entities.Transfer, error)
+	InsertTransfer(transfer entities.Transfer) error
 	UpdateBalance(ID string, balance float64) error
 	ListUserTransfers(CPF string) ([]entities.Transfer, error)
 }

--- a/domain/transfer/usecase/transfer_to.go
+++ b/domain/transfer/usecase/transfer_to.go
@@ -28,12 +28,12 @@ func (t TransferUc) CreateTransfer(accountOrigin, accountDestination entities.Ac
 			return entities.Transfer{}, errors.New("invalid transfer")
 		}
 
-		tr, err := t.r.InsertTransfer(transfer)
+		err = t.r.InsertTransfer(transfer)
 		if err != nil {
 			t.log.WithError(err).Error("unable to save transfer")
 			return entities.Transfer{}, errors.New("unable to save transfer")
 		}
-		return tr, nil
+		return transfer , nil
 	} else {
 		//TODO add a sentinel
 		return entities.Transfer{}, errors.New("insufficient funds")

--- a/domain/transfer/usecase/transfer_to_test.go
+++ b/domain/transfer/usecase/transfer_to_test.go
@@ -35,7 +35,7 @@ func TestCreateTransfer(t *testing.T) {
 			AccountDestinationID: "34add062-ccf4-4530-976d-da7b193a4db4",
 			Amount:               200,
 		}
-		mockRepo.On("InsertTransfer").Return(transferExpected, nil)
+		mockRepo.On("InsertTransfer").Return(nil)
 
 		//test
 		transferReceived, err := transferUC.CreateTransfer(accountOrigin, accountDestination, 200)
@@ -68,7 +68,7 @@ func TestCreateTransfer(t *testing.T) {
 			Secret:  "abc123",
 			Balance: 0,
 		}
-		mockRepo.On("InsertTransfer").Return(entities.Transfer{}, errors.New(""))
+		mockRepo.On("InsertTransfer").Return(errors.New(""))
 
 		//test
 		transferReceived, err := transferUC.CreateTransfer(accountOrigin, accountDestination, 200)
@@ -97,12 +97,7 @@ func TestCreateTransfer(t *testing.T) {
 			Secret:  "abc123",
 			Balance: 0,
 		}
-		transferExpected := entities.Transfer{
-			AccountOriginID:      "2ab7195f-222a-45c3-9189-4f5da5cd745f",
-			AccountDestinationID: "34add062-ccf4-4530-976d-da7b193a4db4",
-			Amount:               200,
-		}
-		mockRepo.On("InsertTransfer").Return(transferExpected, nil)
+		mockRepo.On("InsertTransfer").Return(nil)
 
 		//test
 		transferReceived, err := transferUC.CreateTransfer(accountOrigin, accountDestination, 200)

--- a/domain/transfer/usecase_mock.go
+++ b/domain/transfer/usecase_mock.go
@@ -1,0 +1,22 @@
+package transfer
+
+import (
+	"github.com/francisleide/ChallengeGo/domain/entities"
+	"github.com/stretchr/testify/mock"
+)
+
+type UsecaseMock struct {
+	mock.Mock
+}
+
+func (mock *UsecaseMock) CreateTransfer(accountOrigin, accountDestination entities.Account, amount float64) (entities.Transfer, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.(entities.Transfer), args.Error(1)
+}
+
+func (mock *UsecaseMock) ListUserTransfers(CPF string) ([]entities.Transfer, error) {
+	args := mock.Called()
+	result := args.Get(0)
+	return result.([]entities.Transfer), args.Error(1)
+}

--- a/gateways/db/repository/transfer.go
+++ b/gateways/db/repository/transfer.go
@@ -4,17 +4,17 @@ import (
 	"github.com/francisleide/ChallengeGo/domain/entities"
 )
 
-func (r Repository) InsertTransfer(transfer entities.Transfer) (entities.Transfer, error) {
+func (r Repository) InsertTransfer(transfer entities.Transfer) error {
 
 	_, err := r.Db.Query("insert into transfer (id, account_origin_id, account_destination_id,amount,created_at) values (?,?,?,?,?)",
 		transfer.ID, transfer.AccountOriginID, transfer.AccountDestinationID, transfer.Amount, transfer.CreatedAt)
 
 	if err != nil {
 		r.log.WithError(err).Errorln("failed to insert transfer")
-		return entities.Transfer{}, err
+		return err
 	}
 	r.log.Info("transfer registered successfully")
-	return transfer, nil
+	return nil
 
 }
 
@@ -28,7 +28,7 @@ func (r Repository) ListUserTransfers(accountID string) ([]entities.Transfer, er
 	for rows.Next() {
 		var transfer entities.Transfer
 		err = rows.Scan(&transfer.ID, &transfer.AccountOriginID, &transfer.AccountDestinationID, &transfer.Amount, &transfer.CreatedAt)
-		if err != nil{
+		if err != nil {
 			r.log.WithError(err).Errorln("failed to read record")
 			return []entities.Transfer{}, err
 		}

--- a/gateways/http/account/account_test.go
+++ b/gateways/http/account/account_test.go
@@ -1,0 +1,48 @@
+package account_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/account"
+	"github.com/francisleide/ChallengeGo/domain/entities"
+	a "github.com/francisleide/ChallengeGo/gateways/http/account"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAccount(t *testing.T) {
+	r := mux.NewRouter()
+	t.Run("data is passed correctly and 200 is returned", func(t *testing.T) {
+		accountInput := a.AccountInput{
+			Name:   "Dávila da Vila",
+			CPF:    "63597331025",
+			Secret: "abc123",
+		}
+		newAccount, _ := entities.NewAccount(accountInput.Name, accountInput.CPF, accountInput.Secret)
+		requestBody, _ := json.Marshal(accountInput)
+		req := bytes.NewReader(requestBody)
+
+		resp, _ := json.Marshal(newAccount)
+
+		usecaseFake := new(account.UsecaseMock)
+		usecaseFake.On("CreateAccount").Return(newAccount, nil)
+		log := logrus.NewEntry(logrus.New())
+		handler := a.Accounts(r, usecaseFake, log)
+
+		request := httptest.NewRequest("Post", "/accounts", req)
+
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.CreateAccount).ServeHTTP(response, request)
+
+		assert.Equal(t, string(resp), strings.TrimSpace(response.Body.String()))
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+
+	})
+}

--- a/gateways/http/account/account_test.go
+++ b/gateways/http/account/account_test.go
@@ -19,6 +19,7 @@ import (
 func TestCreateAccount(t *testing.T) {
 	r := mux.NewRouter()
 	t.Run("data is passed correctly and 200 is returned", func(t *testing.T) {
+		//prepare
 		accountInput := a.AccountInput{
 			Name:   "Dávila da Vila",
 			CPF:    "63597331025",
@@ -29,20 +30,21 @@ func TestCreateAccount(t *testing.T) {
 		req := bytes.NewReader(requestBody)
 
 		resp, _ := json.Marshal(newAccount)
-
+		
 		usecaseFake := new(account.UsecaseMock)
 		usecaseFake.On("CreateAccount").Return(newAccount, nil)
 		log := logrus.NewEntry(logrus.New())
 		handler := a.Accounts(r, usecaseFake, log)
-
 		request := httptest.NewRequest("Post", "/accounts", req)
-
 		response := httptest.NewRecorder()
 
+		//test
 		http.HandlerFunc(handler.CreateAccount).ServeHTTP(response, request)
 
+		//assert
 		assert.Equal(t, string(resp), strings.TrimSpace(response.Body.String()))
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 
 	})
 }

--- a/gateways/http/account/create.go
+++ b/gateways/http/account/create.go
@@ -23,7 +23,7 @@ type AccountInput struct {
 func Accounts(serv *mux.Router, usecase account.UseCase, log *logrus.Entry) *Handler {
 	h := &Handler{
 		account: usecase,
-		log: log,
+		log:     log,
 	}
 
 	serv.HandleFunc("/accounts", h.CreateAccount).Methods("Post")
@@ -60,6 +60,7 @@ func (h Handler) CreateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
 	err = json.NewEncoder(w).Encode(account)
 	if err != nil {
 		h.log.WithError(err).Errorln("unable to write json")

--- a/gateways/http/account/create.go
+++ b/gateways/http/account/create.go
@@ -60,7 +60,7 @@ func (h Handler) CreateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(201)
+	w.WriteHeader(http.StatusCreated)
 	err = json.NewEncoder(w).Encode(account)
 	if err != nil {
 		h.log.WithError(err).Errorln("unable to write json")

--- a/gateways/http/account/create_test.go
+++ b/gateways/http/account/create_test.go
@@ -30,7 +30,7 @@ func TestCreateAccount(t *testing.T) {
 		req := bytes.NewReader(requestBody)
 
 		resp, _ := json.Marshal(newAccount)
-		
+
 		usecaseFake := new(account.UsecaseMock)
 		usecaseFake.On("CreateAccount").Return(newAccount, nil)
 		log := logrus.NewEntry(logrus.New())
@@ -43,7 +43,7 @@ func TestCreateAccount(t *testing.T) {
 
 		//assert
 		assert.Equal(t, string(resp), strings.TrimSpace(response.Body.String()))
-		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+		assert.Equal(t, http.StatusCreated, response.Result().StatusCode)
 		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 
 	})

--- a/gateways/http/account/deposit_test.go
+++ b/gateways/http/account/deposit_test.go
@@ -17,24 +17,23 @@ import (
 func TestDeposit(t *testing.T) {
 	r := mux.NewRouter()
 	t.Run("the amount to be deposited is a valid amount and 200 is returned", func(t *testing.T) {
+		//prepare
 		depositInput := a.DepositInput{
 			Amount: 200,
 		}
-
 		requestBody, _ := json.Marshal(depositInput)
 		req := bytes.NewReader(requestBody)
-
 		usecaseFake := new(account.UsecaseMock)
 		usecaseFake.On("Deposit").Return(nil)
 		log := logrus.NewEntry(logrus.New())
 		handler := a.Accounts(r, usecaseFake, log)
-
 		request := httptest.NewRequest("Post", "/deposit", req)
-
 		response := httptest.NewRecorder()
 
+		//test
 		http.HandlerFunc(handler.Deposit).ServeHTTP(response, request)
 
+		//assert
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
 
 	})

--- a/gateways/http/account/deposit_test.go
+++ b/gateways/http/account/deposit_test.go
@@ -1,0 +1,41 @@
+package account_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/account"
+	a "github.com/francisleide/ChallengeGo/gateways/http/account"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeposit(t *testing.T) {
+	r := mux.NewRouter()
+	t.Run("the amount to be deposited is a valid amount and 200 is returned", func(t *testing.T) {
+		depositInput := a.DepositInput{
+			Amount: 200,
+		}
+
+		requestBody, _ := json.Marshal(depositInput)
+		req := bytes.NewReader(requestBody)
+
+		usecaseFake := new(account.UsecaseMock)
+		usecaseFake.On("Deposit").Return(nil)
+		log := logrus.NewEntry(logrus.New())
+		handler := a.Accounts(r, usecaseFake, log)
+
+		request := httptest.NewRequest("Post", "/deposit", req)
+
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.Deposit).ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+
+	})
+}

--- a/gateways/http/account/get_balance_test.go
+++ b/gateways/http/account/get_balance_test.go
@@ -18,9 +18,9 @@ func TestGetBalance(t *testing.T){
 	t.Run("the account id is valid and the balance and status 200 is returned", func(t *testing.T) {
 		//prepare
 		accountID := "efb711fa-786e-4d57-9eeb-6fbaca8775a9"
-		balace := 200.0
+		balance := 200.0
 		usecaseFake := new(account.UsecaseMock)
-		usecaseFake.On("GetBalance").Return(balace, nil)
+		usecaseFake.On("GetBalance").Return(balance, nil)
 		log := logrus.NewEntry(logrus.New())
 		handler := a.Accounts(r, usecaseFake, log)
 		path := fmt.Sprintf("/accounts/%s/balance", accountID)

--- a/gateways/http/account/get_balance_test.go
+++ b/gateways/http/account/get_balance_test.go
@@ -1,0 +1,37 @@
+package account_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/account"
+	a "github.com/francisleide/ChallengeGo/gateways/http/account"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBalance(t *testing.T){
+	r := mux.NewRouter()
+	t.Run("the account id is valid and the balance and status 200 is returned", func(t *testing.T) {
+		accountID := "efb711fa-786e-4d57-9eeb-6fbaca8775a9"
+		balace := 200.0
+
+		usecaseFake := new(account.UsecaseMock)
+		usecaseFake.On("GetBalance").Return(balace, nil)
+		log := logrus.NewEntry(logrus.New())
+		handler := a.Accounts(r, usecaseFake, log)
+		path := fmt.Sprintf("/accounts/%s/balance", accountID)
+		request := httptest.NewRequest("Get", path, nil)
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.GetBalance).ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+		
+
+
+	})
+}

--- a/gateways/http/account/get_balance_test.go
+++ b/gateways/http/account/get_balance_test.go
@@ -16,9 +16,9 @@ import (
 func TestGetBalance(t *testing.T){
 	r := mux.NewRouter()
 	t.Run("the account id is valid and the balance and status 200 is returned", func(t *testing.T) {
+		//prepare
 		accountID := "efb711fa-786e-4d57-9eeb-6fbaca8775a9"
 		balace := 200.0
-
 		usecaseFake := new(account.UsecaseMock)
 		usecaseFake.On("GetBalance").Return(balace, nil)
 		log := logrus.NewEntry(logrus.New())
@@ -27,11 +27,11 @@ func TestGetBalance(t *testing.T){
 		request := httptest.NewRequest("Get", path, nil)
 		response := httptest.NewRecorder()
 
+		//test
 		http.HandlerFunc(handler.GetBalance).ServeHTTP(response, request)
 
+		//assert
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
-		
-
-
+		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 	})
 }

--- a/gateways/http/account/list_account_test.go
+++ b/gateways/http/account/list_account_test.go
@@ -1,8 +1,10 @@
 package account_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/francisleide/ChallengeGo/domain/account"
@@ -35,6 +37,8 @@ func TestListAccount(t *testing.T) {
 		handler := a.Accounts(r, usecaseFake, log)
 		request := httptest.NewRequest("Get", "/accounts", nil)
 		response := httptest.NewRecorder()
+		accounts2, _ := json.Marshal(accounts)
+		//resp := bytes.NewReader(accounts2)
 
 		//test
 		http.HandlerFunc(handler.ListAllAccounts).ServeHTTP(response, request)
@@ -42,5 +46,6 @@ func TestListAccount(t *testing.T) {
 		//assert
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
 		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
+		assert.Equal(t, string(accounts2), strings.TrimSpace(response.Body.String()))
 	})
 }

--- a/gateways/http/account/list_account_test.go
+++ b/gateways/http/account/list_account_test.go
@@ -1,0 +1,45 @@
+package account_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/account"
+	"github.com/francisleide/ChallengeGo/domain/entities"
+	a "github.com/francisleide/ChallengeGo/gateways/http/account"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAccount(t *testing.T){
+	r := mux.NewRouter()
+	t.Run("the list of accounts is displayed and 200 is returned", func(t *testing.T) {
+		accounts := []entities.Account{
+			{
+				Name:    "Lorena Morena",
+				CPF:     "86419560004",
+				Balance: 2000,
+			},
+			{
+				Name:    "Margarete de Albuquerque",
+				CPF:     "47708141001",
+				Balance: 900,
+			},
+		}
+
+		usecaseFake := new(account.UsecaseMock)
+		usecaseFake.On("ListAll").Return(accounts)
+		log := logrus.NewEntry(logrus.New())
+		handler := a.Accounts(r, usecaseFake, log)
+
+		request := httptest.NewRequest("Get", "/accounts", nil)
+
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.Deposit).ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+	})
+}

--- a/gateways/http/account/list_account_test.go
+++ b/gateways/http/account/list_account_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListAccount(t *testing.T){
+func TestListAccount(t *testing.T) {
 	r := mux.NewRouter()
 	t.Run("the list of accounts is displayed and 200 is returned", func(t *testing.T) {
+		//prepare
 		accounts := []entities.Account{
 			{
 				Name:    "Lorena Morena",
@@ -28,18 +29,18 @@ func TestListAccount(t *testing.T){
 				Balance: 900,
 			},
 		}
-
 		usecaseFake := new(account.UsecaseMock)
-		usecaseFake.On("ListAll").Return(accounts)
+		usecaseFake.On("ListAll").Return(accounts, nil)
 		log := logrus.NewEntry(logrus.New())
 		handler := a.Accounts(r, usecaseFake, log)
-
 		request := httptest.NewRequest("Get", "/accounts", nil)
-
 		response := httptest.NewRecorder()
 
-		http.HandlerFunc(handler.Deposit).ServeHTTP(response, request)
+		//test
+		http.HandlerFunc(handler.ListAllAccounts).ServeHTTP(response, request)
 
+		//assert
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+		assert.Equal(t, "application/json", response.Header().Get("Content-Type"))
 	})
 }

--- a/gateways/http/account/withdraw_test.go
+++ b/gateways/http/account/withdraw_test.go
@@ -17,24 +17,24 @@ import (
 func TestWithdraw(t *testing.T) {
 	r := mux.NewRouter()
 	t.Run("the amount to be deposited is a valid amount and 200 is returned", func(t *testing.T) {
+		
+		//prepare
 		withdrawInput := a.Withdraw{
 			Amount: 200,
 		}
-
 		requestBody, _ := json.Marshal(withdrawInput)
 		req := bytes.NewReader(requestBody)
-
 		usecaseFake := new(account.UsecaseMock)
 		usecaseFake.On("Withdraw").Return(nil)
 		log := logrus.NewEntry(logrus.New())
 		handler := a.Accounts(r, usecaseFake, log)
-
 		request := httptest.NewRequest("Post", "/withdraw", req)
-
 		response := httptest.NewRecorder()
 
+		//test
 		http.HandlerFunc(handler.Deposit).ServeHTTP(response, request)
 
+		//assert
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
 
 	})

--- a/gateways/http/account/withdraw_test.go
+++ b/gateways/http/account/withdraw_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestWithdraw(t *testing.T) {
 	r := mux.NewRouter()
-	t.Run("the amount to be deposited is a valid amount and 200 is returned", func(t *testing.T) {
+	t.Run("The withdrawal amount is valid and 200 is returned", func(t *testing.T) {
 		
 		//prepare
 		withdrawInput := a.Withdraw{

--- a/gateways/http/account/withdraw_test.go
+++ b/gateways/http/account/withdraw_test.go
@@ -1,0 +1,41 @@
+package account_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/account"
+	a "github.com/francisleide/ChallengeGo/gateways/http/account"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithdraw(t *testing.T) {
+	r := mux.NewRouter()
+	t.Run("the amount to be deposited is a valid amount and 200 is returned", func(t *testing.T) {
+		withdrawInput := a.Withdraw{
+			Amount: 200,
+		}
+
+		requestBody, _ := json.Marshal(withdrawInput)
+		req := bytes.NewReader(requestBody)
+
+		usecaseFake := new(account.UsecaseMock)
+		usecaseFake.On("Withdraw").Return(nil)
+		log := logrus.NewEntry(logrus.New())
+		handler := a.Accounts(r, usecaseFake, log)
+
+		request := httptest.NewRequest("Post", "/withdraw", req)
+
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.Deposit).ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+
+	})
+}

--- a/gateways/http/auth/auth_test.go
+++ b/gateways/http/auth/auth_test.go
@@ -17,6 +17,7 @@ import (
 func TestAuthentication(t *testing.T) {
 	r := mux.NewRouter()
 	t.Run("login and password data are passed correctly and 200 is returned", func(t *testing.T) {
+		//prepare
 		log := logrus.NewEntry(logrus.New())
 		account := a.Login{
 			CPF:    "86594861026",
@@ -24,19 +25,17 @@ func TestAuthentication(t *testing.T) {
 		}
 		requestBody, _ := json.Marshal(account)
 		req := bytes.NewReader(requestBody)
-
 		usecaseFake := new(auth.UsecaseMock)
 		usecaseFake.On("CreateToken").Return("valid-token", nil)
-
 		handler := a.Auth(r, usecaseFake, log)
-
 		request := httptest.NewRequest("Post", "/login", req)
-
 		response := httptest.NewRecorder()
 
+		//test
 		http.HandlerFunc(handler.Authentication).ServeHTTP(response, request)
 
+		//assert
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
-
+		assert.NotEmpty(t, response)
 	})
 }

--- a/gateways/http/auth/auth_test.go
+++ b/gateways/http/auth/auth_test.go
@@ -1,0 +1,42 @@
+package auth_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/auth"
+	a "github.com/francisleide/ChallengeGo/gateways/http/auth"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthentication(t *testing.T) {
+	r := mux.NewRouter()
+	t.Run("login and password data are passed correctly and 200 is returned", func(t *testing.T) {
+		log := logrus.NewEntry(logrus.New())
+		account := a.Login{
+			CPF:    "86594861026",
+			Secret: "123abc",
+		}
+		requestBody, _ := json.Marshal(account)
+		req := bytes.NewReader(requestBody)
+
+		usecaseFake := new(auth.UsecaseMock)
+		usecaseFake.On("CreateToken").Return("valid-token", nil)
+
+		handler := a.Auth(r, usecaseFake, log)
+
+		request := httptest.NewRequest("Post", "/login", req)
+
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.Authentication).ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+
+	})
+}

--- a/gateways/http/transfer/transfer_test.go
+++ b/gateways/http/transfer/transfer_test.go
@@ -1,0 +1,57 @@
+package transfer_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/francisleide/ChallengeGo/domain/account"
+	"github.com/francisleide/ChallengeGo/domain/entities"
+	"github.com/francisleide/ChallengeGo/domain/transfer"
+	tr "github.com/francisleide/ChallengeGo/gateways/http/transfer"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTransfer(t *testing.T) {
+	r := mux.NewRouter()
+	t.Run("the data was passed correctly and status 200 is returned", func(t *testing.T) {
+		log := logrus.NewEntry(logrus.New())
+		accountOrigin := entities.Account{
+			ID:      "efb711fa-786e-4d57-9eeb-6fbaca8775a9",
+			Name:    "Ana Mariana",
+			Balance: 100,
+		}
+		accountDestination := entities.Account{
+			ID:      "8b27748e-88a8-4792-b22a-67ba8f77179f",
+			Name:    "Flávio Sábio",
+			Balance: 0,
+		}
+		transferInput := tr.TransferInput{
+			AccountDestinationID: "280160d0-5c66-4faf-97c8-1512f90da152",
+			Amount:               200,
+		}
+
+		requestBody, _ := json.Marshal(transferInput)
+		req := bytes.NewReader(requestBody)
+		usecaseFakeAccount := new(account.UsecaseMock)
+		usecaseFakeTransfer := new(transfer.UsecaseMock)
+		usecaseFakeAccount.On("GetAccountByCPF").Return(accountOrigin, nil)
+		usecaseFakeAccount.On("GetAccountByCPF").Return(accountDestination, nil)
+		usecaseFakeTransfer.On("CreateTransfer").Return()
+
+		handler := tr.NewTransfer(r, usecaseFakeTransfer, usecaseFakeAccount, log)
+
+		request := httptest.NewRequest("Post", "/transfer", req)
+
+		response := httptest.NewRecorder()
+
+		http.HandlerFunc(handler.CreateTransfer).ServeHTTP(response, request)
+
+		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
+
+	})
+}

--- a/gateways/http/transfer/transfer_test.go
+++ b/gateways/http/transfer/transfer_test.go
@@ -32,8 +32,8 @@ func TestCreateTransfer(t *testing.T) {
 			Balance: 0,
 		}
 		transferInput := tr.TransferInput{
-			AccountDestinationID: "280160d0-5c66-4faf-97c8-1512f90da152",
-			Amount:               200,
+			AccountDestinationID: "8b27748e-88a8-4792-b22a-67ba8f77179f",
+			Amount:               50,
 		}
 
 		requestBody, _ := json.Marshal(transferInput)

--- a/gateways/http/transfer/transfer_test.go
+++ b/gateways/http/transfer/transfer_test.go
@@ -19,6 +19,7 @@ import (
 func TestCreateTransfer(t *testing.T) {
 	r := mux.NewRouter()
 	t.Run("the data was passed correctly and status 200 is returned", func(t *testing.T) {
+		//prepare
 		log := logrus.NewEntry(logrus.New())
 		accountOrigin := entities.Account{
 			ID:      "efb711fa-786e-4d57-9eeb-6fbaca8775a9",
@@ -42,16 +43,14 @@ func TestCreateTransfer(t *testing.T) {
 		usecaseFakeAccount.On("GetAccountByCPF").Return(accountOrigin, nil)
 		usecaseFakeAccount.On("GetAccountByCPF").Return(accountDestination, nil)
 		usecaseFakeTransfer.On("CreateTransfer").Return()
-
 		handler := tr.NewTransfer(r, usecaseFakeTransfer, usecaseFakeAccount, log)
-
 		request := httptest.NewRequest("Post", "/transfer", req)
-
 		response := httptest.NewRecorder()
 
+		//test
 		http.HandlerFunc(handler.CreateTransfer).ServeHTTP(response, request)
 
+		//test
 		assert.Equal(t, http.StatusOK, response.Result().StatusCode)
-
 	})
 }


### PR DESCRIPTION
Added unit tests to API handlers. Also fixed the return of a repository function, as there was no need to return the transfer object.